### PR TITLE
Add filename option to S3Client#upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ end
 - `path`: defaults to `nil`, but this is where you put a custom folder if you so wish (in relation
   to your `root_path`, which if you didn't configure in your initializer, will be your root Dropbox
   folder `/`.
+- `filename`: defaults to the name of the file you are uploading, but you can specify a custom name here.
 - `file`: The file object that you are uploading, ex: `file = File.open('./path-to-local-file').
 - `cleanup`: defaults to `false`, but if you pass `true` - it will remove the local file after uploading.
 - `public`: defaults to `false`. Pass `true` if you'd like to set the file permission level to world readable.

--- a/breadbox.gemspec
+++ b/breadbox.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "dropbox-sdk", "~> 1.6"
+  spec.add_dependency "dropbox-sdk", "~> 1.6.4"
   spec.add_dependency "aws-sdk", "~> 2.1.7"
 
   spec.add_development_dependency "bundler", "~> 1.6"

--- a/lib/breadbox/client.rb
+++ b/lib/breadbox/client.rb
@@ -23,8 +23,7 @@ module Breadbox
 
     protected
 
-    def filepath_from_paths_and_file(root_path, path, file)
-      filename = File.basename(file)
+    def filepath_from_paths_and_filename(root_path, path, filename)
       [root_path, path, filename].join("/").gsub(/\/{2,}/, "/")
     end
 

--- a/lib/breadbox/dropbox_client.rb
+++ b/lib/breadbox/dropbox_client.rb
@@ -10,9 +10,11 @@ module Breadbox
     def upload(options = {})
       path      = options[:path]
       file      = options[:file]
+      filename  = options[:filename]  || File.basename(file)
       overwrite = options[:overwrite] || false
       share     = options[:share]
-      filepath  = filepath_from_paths_and_file(root_path, path, file)
+
+      filepath  = filepath_from_paths_and_filename(root_path, path, filename)
       result    = client.put_file(filepath, file, overwrite)
 
       if share && result

--- a/lib/breadbox/s3_client.rb
+++ b/lib/breadbox/s3_client.rb
@@ -14,9 +14,10 @@ module Breadbox
     def upload(options = {})
       path          = options[:path]
       file          = options[:file]
+      filename      = options[:filename] || File.basename(file)
       acl           = options[:public] ? :public_read : :private
       content_type  = options[:content_type]
-      filepath      = filepath_from_paths_and_file(root_path, path, file)[1..-1]
+      filepath      = filepath_from_paths_and_filename(root_path, path, filename)[1..-1]
       s3_object     = s3_bucket_object.object(filepath)
 
       result = s3_object.put(body: file, acl: acl, content_type: content_type)

--- a/lib/breadbox/version.rb
+++ b/lib/breadbox/version.rb
@@ -1,3 +1,3 @@
 module Breadbox
-  VERSION = "1.3.0"
+  VERSION = "1.4.0"
 end

--- a/spec/breadbox/dropbox_client_spec.rb
+++ b/spec/breadbox/dropbox_client_spec.rb
@@ -63,6 +63,17 @@ module Breadbox
 
         client.upload(path: "/", file: file)
       end
+
+      it "allows for a filename to be passed as an option" do
+        file           = File.open("./tmp/new-file.jpg")
+        client         = DropboxClient.new(configuration)
+        dropbox_client = instance_double(::DropboxClient)
+        allow(client).to receive(:client).and_return(dropbox_client)
+        expect(dropbox_client).to receive(:put_file)
+                                  .with("/my-cool-file.jpg", file, false)
+
+        client.upload(path: "/", file: file, filename: "my-cool-file.jpg")
+      end
     end
   end
 end

--- a/spec/breadbox/s3_client_spec.rb
+++ b/spec/breadbox/s3_client_spec.rb
@@ -112,6 +112,33 @@ module Breadbox
 
         client.upload(path: "/", file: file, public: nil, content_type: "image/jpeg")
       end
+
+      it "passes path parameter" do
+        file    = File.open("./tmp/new-file.jpg")
+        bucket_object = client.s3_bucket_object.object("new-file.jpg")
+
+        expect_any_instance_of(Aws::S3::Bucket).to receive(:object)
+          .with("my-path/new-file.jpg").and_return(bucket_object)
+        expect(bucket_object).to receive(:put)
+
+        client.upload(path: "my-path", file: file, content_type: "image/jpeg")
+      end
+
+      it "passes filename parameter" do
+        file    = File.open("./tmp/new-file.jpg")
+        bucket_object = client.s3_bucket_object.object("my-cool-filename.jpg")
+
+        expect_any_instance_of(Aws::S3::Bucket).to receive(:object)
+          .with("my-cool-filename.jpg").and_return(bucket_object)
+        expect(bucket_object).to receive(:put)
+
+        client.upload(
+          path: "/",
+          file: file,
+          filename: "my-cool-filename.jpg",
+          content_type: "image/jpeg"
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
Adds the ability to specify the filename for the file that is uploaded to S3. Previously, the filename of the file being uploaded was always used.
