### PR TITLE
Update aws-sdk Dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ end
 # config/initializers/breadbox.rb
 
 Breadbox.configure do |config|
+  config.s3_region = xxxxxxxx             # OPTIONAL - defaults to "us-east-1"
   config.s3_bucket = "name of the bucket" # THIS IS REQUIRED
   config.s3_secret_access_key = xxxxxx    # THIS IS REQUIRED
   config.s3_access_key_id = xxxxxxx       # THIS IS REQUIRED

--- a/breadbox.gemspec
+++ b/breadbox.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "dropbox-sdk", "~> 1.6"
-  spec.add_dependency "aws-sdk", "~> 1.54"
+  spec.add_dependency "aws-sdk", "~> 2.1.7"
 
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake"

--- a/lib/breadbox/configuration.rb
+++ b/lib/breadbox/configuration.rb
@@ -7,6 +7,8 @@ module Breadbox
                   :provider,
                   :root_path
 
+    attr_writer :s3_region
+
     def initialize
       @root_path = default_root_path
     end
@@ -19,7 +21,15 @@ module Breadbox
       end
     end
 
+    def s3_region
+      @s3_region || default_s3_region
+    end
+
     protected
+
+    def default_s3_region
+      "us-east-1"
+    end
 
     def default_root_path
       "/"

--- a/lib/breadbox/version.rb
+++ b/lib/breadbox/version.rb
@@ -1,3 +1,3 @@
 module Breadbox
-  VERSION = "1.2.1"
+  VERSION = "1.3.0"
 end


### PR DESCRIPTION
This adds a configuration option (`s3_region`) for `Breadbox`.

Breadbox will default to `us-east-1`, but you can set it in your
configuration settings:

```ruby
Breadbox.configure do |config|
  config.s3_region = "us-west-3" # defaults to "us-east-1"
end
```

Also - the internals have been swapped out to use the new `Aws::S3`
objects, and creating a new `Breadbox::S3Client` no longer modifies the
global `Aws` credentials (in the event of using `Aws` somewhere else in
your application, and the credentials aren't the same).